### PR TITLE
Fix possible fix(deps): golang.org/x/text v0.14.0 → 0.39.0 (CVE-2026-56852) in go.mod

### DIFF
--- a/engine/go.mod
+++ b/engine/go.mod
@@ -8,4 +8,4 @@ require (
 	gopkg.in/yaml.v3 v3.0.1
 )
 
-require golang.org/x/text v0.14.0 // indirect
+require golang.org/x/text v0.39.0 // indirect


### PR DESCRIPTION
This changes `engine/go.mod` to address something a scan flagged. It is around line 1.

The golang.org/x/text package version 0.14.0 contains an infinite-loop bug (CVE‑2026‑56852) in norm.Iter when processing input that contains invalid UTF‑8 bytes. This can lead to a denial‑of‑service (DoS) condition where the application hangs or consumes excessive CPU while normalizing strings, posing a high risk for services that handle arbitrary user input. Upgrading to version 0.39.0, which includes a fix for the bug, mitigates the issue.

Upgrade golang.org/x/text from v0.14.0 to v0.39.0 to fix CVE-2026-56852.

For reference: rule `CVE-2026-56852`. Rated high.

I may well be missing context here — if the current code is deliberate, feel free to close this.

---
*Found with automated scanning ([RedGem](https://code.redgem.net)) and reviewed before opening. If it is not useful, closing it is completely fine.*
